### PR TITLE
Implement basic M&A analysis utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # Playground exports (if any)
 *.json
+__pycache__/

--- a/mna_quant/analysis_functions.py
+++ b/mna_quant/analysis_functions.py
@@ -1,0 +1,97 @@
+"""Utility functions for simple M&A quantitative analysis."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Dict, Any
+
+
+@dataclass
+class ComplianceResult:
+    section_count: int
+    ambiguity_score: float
+    missing_clauses: List[str]
+
+
+def analyze_agreement_structure_and_compliance(
+    agreement_text: str,
+    deal_context: Dict[str, Any],
+    evaluation_profile: Dict[str, Any],
+) -> ComplianceResult:
+    """Rudimentary analysis of section structure and clause presence."""
+    # Count sections by detecting typical section headers like "1." or "Section 1"
+    section_pattern = re.compile(r"^(?:\d+\.|section\s+\d+)", re.IGNORECASE | re.MULTILINE)
+    sections = section_pattern.findall(agreement_text)
+    section_count = len(sections)
+
+    # Ambiguity score: ratio of ambiguous modal verbs to total sentences
+    ambiguous_terms = re.findall(r"\b(?:may|might|could|should)\b", agreement_text, re.IGNORECASE)
+    sentences = re.split(r"[.!?]+", agreement_text)
+    ambiguity_score = len(ambiguous_terms) / max(len(sentences), 1)
+
+    # Clause checklist compliance
+    checklist = evaluation_profile.get("critical_clauses_checklist", [])
+    missing = []
+    for clause in checklist:
+        pattern = re.compile(re.escape(clause), re.IGNORECASE)
+        if not pattern.search(agreement_text):
+            missing.append(clause)
+
+    return ComplianceResult(
+        section_count=section_count,
+        ambiguity_score=round(ambiguity_score, 3),
+        missing_clauses=missing,
+    )
+
+
+@dataclass
+class RiskItem:
+    category: str
+    severity: int
+    likelihood: int
+
+
+def identify_and_quantify_deal_risks(
+    agreement_text: str,
+    deal_context: Dict[str, Any],
+    risk_assessment_parameters: Dict[str, Any],
+) -> List[RiskItem]:
+    """Simple keyword based risk extraction."""
+    categories = risk_assessment_parameters.get(
+        "risk_categories_to_scan",
+        [
+            "Legal_Compliance",
+            "Financial_Exposure",
+            "Operational_Disruption",
+        ],
+    )
+    severity_max = risk_assessment_parameters.get("severity_scale_max", 5)
+    likelihood_max = risk_assessment_parameters.get("likelihood_scale_max", 5)
+
+    results: List[RiskItem] = []
+    for cat in categories:
+        pattern = re.compile(cat.replace("_", " "), re.IGNORECASE)
+        hits = len(pattern.findall(agreement_text))
+        if hits:
+            severity = min(severity_max, hits)
+            likelihood = min(likelihood_max, 1 + hits // 2)
+            results.append(RiskItem(cat, severity, likelihood))
+    return results
+
+
+def predict_deal_closure_probability(
+    deal_financials_input: Dict[str, Any],
+    deal_structure_input: Dict[str, Any],
+    agreement_analysis_input: Dict[str, Any],
+    market_context_input: Dict[str, Any],
+    prediction_model_config: Dict[str, Any],
+) -> float:
+    """Naive scoring model returning probability 0-100."""
+    base = 50.0
+    base += deal_financials_input.get("deal_value_usd_M", 0) / 1000.0
+    base += market_context_input.get("regulatory_hurdle_score_1_5", 3) * (-2)
+    base -= len(agreement_analysis_input.get("missing_clauses", [])) * 3
+    base = max(0.0, min(100.0, base))
+    return round(base, 2)
+
+

--- a/tests/test_analysis_functions.py
+++ b/tests/test_analysis_functions.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from mna_quant.analysis_functions import (
+    analyze_agreement_structure_and_compliance,
+    identify_and_quantify_deal_risks,
+    predict_deal_closure_probability,
+    ComplianceResult,
+)
+
+
+def test_analyze_agreement_structure_and_compliance():
+    text = "Section 1\nThis Agreement shall...\nSection 2\nThe Buyer may..."
+    profile = {"critical_clauses_checklist": ["MAC", "Non_Compete"]}
+    result = analyze_agreement_structure_and_compliance(text, {}, profile)
+    assert isinstance(result, ComplianceResult)
+    assert result.section_count == 2
+    assert result.ambiguity_score >= 0
+    assert "MAC" in result.missing_clauses
+
+
+def test_identify_and_quantify_deal_risks():
+    text = "Legal compliance is essential. Financial exposure may occur."
+    params = {
+        "risk_categories_to_scan": ["Legal_Compliance", "Financial_Exposure"],
+        "severity_scale_max": 5,
+        "likelihood_scale_max": 5,
+    }
+    risks = identify_and_quantify_deal_risks(text, {}, params)
+    assert len(risks) == 2
+    categories = {r.category for r in risks}
+    assert categories == {"Legal_Compliance", "Financial_Exposure"}
+
+
+def test_predict_deal_closure_probability():
+    prob = predict_deal_closure_probability(
+        deal_financials_input={"deal_value_usd_M": 500},
+        deal_structure_input={},
+        agreement_analysis_input={"missing_clauses": ["MAC"]},
+        market_context_input={"regulatory_hurdle_score_1_5": 4},
+        prediction_model_config={},
+    )
+    assert 0 <= prob <= 100


### PR DESCRIPTION
## Summary
- add simple M&A quantitative analysis utilities
- add pytest unit tests
- ignore `__pycache__`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bf0b3c1548330b34ef08d3456d00d